### PR TITLE
[Enhancement] Support to configure thrift MAX_MESSAGE_SIZE

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/cfg/ConfigurationOptions.java
+++ b/src/main/java/com/starrocks/connector/spark/cfg/ConfigurationOptions.java
@@ -65,4 +65,7 @@ public interface ConfigurationOptions {
 
     String STARROCKS_DESERIALIZE_QUEUE_SIZE = "starrocks.deserialize.queue.size";
     int STARROCKS_DESERIALIZE_QUEUE_SIZE_DEFAULT = 64;
+
+    String STARROCKS_THRIFT_MAX_MESSAGE_SIZE = "starrocks.thrift.max.message.size";
+    int STARROCKS_THRIFT_MAX_MESSAGE_SIZE_DEFAULT = Integer.MAX_VALUE;
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks-connector-for-apache-spark/issues/13

## Problem Summary(Required) ：
Scanning a big batch of data may reach the [MaxMessageSize](https://github.com/apache/thrift/blob/master/doc/specs/thrift-tconfiguration.md#maxmessagesize) of thrift. One solution is to decrease `starrocks.batch.size`, but it will affect the performance. So we should add a configuration to increase the `MAX_MESSAGE_SIZE`.